### PR TITLE
feat: cascading dropdowns, styled tables & chart utilities

### DIFF
--- a/examples/example_35_cascading_report.py
+++ b/examples/example_35_cascading_report.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""
+Example 35: Cascading Dropdowns, Styled Tables & Chart Utilities
+================================================================
+
+Demonstrates the new interactive report features:
+1. add_cascading_content — multi-dimensional dropdown navigation
+2. add_dataframe with thresholds — conditional formatting
+3. index_chart — normalized index charts with toggle buttons
+4. stacked_area_comparison — side-by-side 100% stacked areas
+"""
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from scomp_link.utils.plotly_utils import (
+    fill_timeslots,
+    index_chart,
+    normalize_to_index,
+    stacked_area_comparison,
+)
+from scomp_link.utils.report_html import ScompLinkHTMLReport
+
+
+def main():
+    # --- Setup report ---
+    report = ScompLinkHTMLReport("Cascading Report Demo")
+    report.add_title("Interactive Report Features Demo")
+    report.add_text("This report demonstrates cascading dropdowns, styled tables, and chart utilities.")
+
+    # ==========================================================
+    # 1. Cascading Content with Plotly Figures
+    # ==========================================================
+    report.open_section("Cascading Dropdowns — Plotly Figures")
+    report.add_text(
+        "Select a region and metric to view the corresponding chart. "
+        "Dropdowns update the visible content instantly without page reload."
+    )
+
+    # Generate sample figures for each combination
+    np.random.seed(42)
+    regions = ["North", "South", "East"]
+    metrics = ["Revenue", "Users"]
+    content_map = {}
+    for region in regions:
+        for metric in metrics:
+            x = list(range(1, 13))
+            y = np.random.randint(50, 200, size=12).tolist()
+            fig = go.Figure(data=[go.Bar(x=x, y=y, marker_color="#6E37FA")])
+            fig.update_layout(
+                title=f"{region} — {metric}",
+                xaxis_title="Month",
+                yaxis_title=metric,
+                height=350,
+            )
+            content_map[(region, metric)] = fig
+
+    dimensions = [
+        {"label": "Region", "options": regions},
+        {"label": "Metric", "options": metrics},
+    ]
+    report.add_cascading_content("Regional Performance", dimensions, content_map)
+    report.close_section()
+
+    # ==========================================================
+    # 2. Cascading Content with HTML (cascade=True)
+    # ==========================================================
+    report.open_section("Cascading Dropdowns — HTML Content (cascade mode)")
+    report.add_text(
+        "In cascade mode, the second dropdown options are filtered based on the first selection."
+    )
+
+    countries = ["US", "Germany"]
+    cities_map = {"US": ["New York", "Los Angeles"], "Germany": ["Berlin", "Munich"]}
+    content_cascade = {}
+    for country, cities in cities_map.items():
+        for city in cities:
+            content_cascade[(country, city)] = (
+                f"<div style='padding:1rem;background:#f0f4ff;border-radius:8px;'>"
+                f"<h3>{city}, {country}</h3>"
+                f"<p>Population data and statistics for {city} would appear here.</p>"
+                f"</div>"
+            )
+
+    all_cities = [c for cities in cities_map.values() for c in cities]
+    dims_cascade = [
+        {"label": "Country", "options": countries},
+        {"label": "City", "options": all_cities},
+    ]
+    report.add_cascading_content("City Explorer", dims_cascade, content_cascade, cascade=True)
+    report.close_section()
+
+    # ==========================================================
+    # 3. Styled DataFrame with Thresholds
+    # ==========================================================
+    report.open_section("Styled Tables with Conditional Formatting")
+    report.add_text(
+        "Tables with threshold-based coloring: green = good, orange = warning, red = critical."
+    )
+
+    metrics_df = pd.DataFrame({
+        "model": ["RandomForest", "XGBoost", "LinearReg", "SVM", "KNN"],
+        "rmse": [0.08, 0.12, 0.28, 0.19, 0.35],
+        "r2_score": [0.95, 0.88, 0.72, 0.55, 0.40],
+        "train_time_s": [2.1, 1.8, 0.3, 5.2, 0.8],
+    })
+
+    thresholds = {
+        "rmse": (0.10, 0.25, False),       # lower is better
+        "r2_score": (0.85, 0.60, True),    # higher is better
+        "train_time_s": (2.0, 4.0, False), # lower is better
+    }
+
+    report.add_dataframe(metrics_df, "Model Comparison", thresholds=thresholds)
+    report.close_section()
+
+    # ==========================================================
+    # 4. Index Chart
+    # ==========================================================
+    report.open_section("Index Chart Utility")
+    report.add_text(
+        "Index charts normalize series to baseline=100 (daily average). "
+        "Use toggle buttons to switch between groups."
+    )
+
+    hours = [f"{h:02d}:00" for h in range(24)]
+    np.random.seed(123)
+
+    fig_index = index_chart(
+        series_dict={
+            "Young (18-34)": {
+                "solid": np.random.exponential(3, 24).tolist(),
+                "dashed": (np.random.exponential(3, 24) * 0.9).tolist(),
+            },
+            "Middle (35-54)": {
+                "solid": (np.random.normal(5, 1, 24).clip(0)).tolist(),
+                "dashed": (np.random.normal(5, 1.2, 24).clip(0)).tolist(),
+            },
+            "Senior (55+)": {
+                "solid": (np.random.normal(4, 0.8, 24).clip(0)).tolist(),
+                "dashed": (np.random.normal(4, 1, 24).clip(0)).tolist(),
+            },
+        },
+        x_labels=hours,
+        title="Viewing Index by Age Group",
+        baseline=100,
+    )
+    report.add_graph_to_report(fig_index, "Viewing Index")
+    report.close_section()
+
+    # ==========================================================
+    # 5. Stacked Area Comparison
+    # ==========================================================
+    report.open_section("Stacked Area Comparison Utility")
+    report.add_text(
+        "Side-by-side stacked areas show composition differences between two sources. "
+        "Each slot sums to 100%."
+    )
+
+    time_labels = [f"{h:02d}:{'00' if h % 2 == 0 else '30'}" for h in range(12)]
+    fig_stacked = stacked_area_comparison(
+        data_left={"Youth": [30, 25, 20, 15, 10, 15, 20, 30, 35, 30, 25, 20],
+                   "Adults": [50, 55, 60, 65, 70, 65, 60, 50, 45, 50, 55, 60],
+                   "Seniors": [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20]},
+        data_right={"Youth": [25, 22, 18, 12, 8, 12, 18, 28, 32, 28, 22, 18],
+                    "Adults": [55, 58, 62, 68, 72, 68, 62, 52, 48, 52, 58, 62],
+                    "Seniors": [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20]},
+        categories=["Youth", "Adults", "Seniors"],
+        x_labels=time_labels,
+        title="Audience Composition: Source A vs Source B",
+        subplot_titles=("Source A", "Source B"),
+    )
+    report.add_graph_to_report(fig_stacked, "Composition Comparison")
+    report.close_section()
+
+    # ==========================================================
+    # 6. Utility functions demo
+    # ==========================================================
+    report.open_section("Utility Functions")
+
+    # fill_timeslots
+    partial_data = [10, 20, 30]
+    filled = fill_timeslots(partial_data, n_slots=8, fill_value=0)
+    report.add_text(f"<code>fill_timeslots([10, 20, 30], n_slots=8)</code> → {filled.tolist()}")
+
+    # normalize_to_index
+    raw = [2, 4, 6, 8]
+    indexed = normalize_to_index(raw, baseline=100)
+    report.add_text(f"<code>normalize_to_index([2, 4, 6, 8], baseline=100)</code> → {[round(v, 1) for v in indexed.tolist()]}")
+
+    report.close_section()
+
+    # --- Save ---
+    output_path = "cascading_report_demo.html"
+    report.save_html(output_path)
+    print(f"Report saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scomp_link/utils/plotly_utils.py
+++ b/scomp_link/utils/plotly_utils.py
@@ -389,6 +389,238 @@ def linechart(
     return fig
 
 
+def fill_timeslots(values, n_slots: int, fill_value: float = 0.0) -> np.ndarray:
+    """Ensure array has exactly n_slots elements, padding or truncating as needed.
+
+    Useful for preparing time-series data where some slots may be missing.
+
+    :param values: list or array of numeric values
+    :param n_slots: desired output length
+    :param fill_value: value used to pad if input is shorter (default 0.0)
+    :return: numpy array of length n_slots
+
+    ## example
+    from scomp_link.utils.plotly_utils import fill_timeslots
+    result = fill_timeslots([1, 2, 3], n_slots=5)  # [1, 2, 3, 0, 0]
+    """
+    arr = np.asarray(values, dtype=float)
+    if len(arr) >= n_slots:
+        return arr[:n_slots]
+    padded = np.full(n_slots, fill_value, dtype=float)
+    padded[:len(arr)] = arr
+    return padded
+
+
+def normalize_to_index(values, baseline: float = 100.0) -> np.ndarray:
+    """Normalize array so that its mean equals the baseline value.
+
+    Useful for creating index charts where baseline=100 represents the average.
+    Returns zeros if the input mean is zero.
+
+    :param values: list or array of numeric values
+    :param baseline: target mean value (default 100.0)
+    :return: numpy array with mean approximately equal to baseline
+
+    ## example
+    from scomp_link.utils.plotly_utils import normalize_to_index
+    result = normalize_to_index([2, 4, 6], baseline=100)  # [50, 100, 150]
+    """
+    arr = np.asarray(values, dtype=float)
+    mean_val = arr.mean()
+    if mean_val == 0:
+        return np.zeros_like(arr)
+    return arr / mean_val * baseline
+
+
+def index_chart(
+    series_dict: dict,
+    x_labels: list[str],
+    title: str,
+    baseline: float = 100.0,
+    height: int = 400,
+    colors: list[str] | None = None,
+) -> go.Figure:
+    """Create an index chart with toggle buttons to switch between series groups.
+
+    Each series is normalized so its mean equals `baseline` (default 100).
+    A horizontal reference line is drawn at the baseline.
+
+    series_dict formats:
+    - Simple: {"A": [values], "B": [values]} — one solid trace per key
+    - Paired: {"A": {"solid": [values], "dashed": [values]}} — two traces per key
+
+    :param series_dict: dict mapping series names to values or {"solid": ..., "dashed": ...}
+    :param x_labels: list of x-axis labels
+    :param title: chart title
+    :param baseline: index baseline value (default 100)
+    :param height: chart height in pixels (default 400)
+    :param colors: optional list of colors for series (cycles if fewer than series)
+    :return: plotly Figure
+
+    ## example
+    from scomp_link.utils.plotly_utils import index_chart
+    fig = index_chart(
+        {"Group A": {"solid": [2,4,3,5], "dashed": [3,3,4,4]},
+         "Group B": {"solid": [5,3,4,2], "dashed": [4,4,3,3]}},
+        x_labels=["Q1", "Q2", "Q3", "Q4"],
+        title="Performance Index"
+    )
+    """
+    default_colors = [c for group in [PRIMARY, MEDIUM, DARK, MEDIUM_LIGHT, MEDIUM_DARK, DARKEST, LIGHT] for c in group]
+    palette = colors or default_colors
+
+    fig = go.Figure()
+
+    # Determine format
+    first_val = next(iter(series_dict.values()))
+    is_paired = isinstance(first_val, dict)
+
+    group_names = list(series_dict.keys())
+    traces_per_group = 2 if is_paired else 1
+
+    for i, (name, data) in enumerate(series_dict.items()):
+        color = palette[i % len(palette)]
+        visible = (i == 0)
+
+        if is_paired:
+            solid_vals = normalize_to_index(data["solid"], baseline)
+            dashed_vals = normalize_to_index(data["dashed"], baseline)
+            fig.add_trace(go.Scatter(
+                x=x_labels, y=solid_vals.tolist(),
+                name=f"{name} (solid)", line=dict(color=color, width=3),
+                mode="lines", visible=visible,
+            ))
+            fig.add_trace(go.Scatter(
+                x=x_labels, y=dashed_vals.tolist(),
+                name=f"{name} (dashed)", line=dict(color=color, width=3, dash="dash"),
+                mode="lines", visible=visible,
+            ))
+        else:
+            vals = normalize_to_index(data, baseline)
+            fig.add_trace(go.Scatter(
+                x=x_labels, y=vals.tolist(),
+                name=name, line=dict(color=color, width=3),
+                mode="lines", visible=visible,
+            ))
+
+    fig.add_hline(y=baseline, line_dash="dot", line_color="rgba(128,128,128,0.4)")
+
+    # Toggle buttons
+    total_traces = len(group_names) * traces_per_group
+    buttons = []
+    for i, name in enumerate(group_names):
+        vis = [False] * total_traces
+        for j in range(traces_per_group):
+            vis[i * traces_per_group + j] = True
+        buttons.append(dict(
+            label=f"  {name}  ", method="update",
+            args=[{"visible": vis}, {"title": f"{title} — {name}"}],
+        ))
+
+    # "All" button
+    buttons.append(dict(
+        label="  All  ", method="update",
+        args=[{"visible": [True] * total_traces}, {"title": title}],
+    ))
+
+    fig.update_layout(
+        title=f"{title} — {group_names[0]}" if group_names else title,
+        height=height,
+        xaxis_title="", yaxis_title=f"Index ({baseline} = average)",
+        xaxis=dict(tickangle=45),
+        legend=dict(orientation="h", yanchor="bottom", y=1.05, xanchor="center", x=0.5),
+        updatemenus=[dict(
+            type="buttons", direction="right",
+            x=0.5, xanchor="center", y=-0.2, yanchor="top",
+            buttons=buttons,
+        )],
+        margin=dict(b=100),
+    )
+    return fig
+
+
+def stacked_area_comparison(
+    data_left: dict[str, list[float]],
+    data_right: dict[str, list[float]],
+    categories: list[str],
+    x_labels: list[str],
+    title: str,
+    subplot_titles: tuple[str, str] = ("Left", "Right"),
+    height: int = 400,
+    colors: list[str] | None = None,
+) -> go.Figure:
+    """Create side-by-side 100%% stacked area charts for comparison.
+
+    Each slot sums to 100%%. Useful for comparing composition between two sources.
+
+    :param data_left: dict mapping category names to value lists for left subplot
+    :param data_right: dict mapping category names to value lists for right subplot
+    :param categories: ordered list of category names (determines stacking order and legend)
+    :param x_labels: x-axis labels
+    :param title: overall chart title
+    :param subplot_titles: tuple of (left_title, right_title)
+    :param height: chart height in pixels (default 400)
+    :param colors: optional list of colors for categories
+    :return: plotly Figure with 2 subplots
+
+    ## example
+    from scomp_link.utils.plotly_utils import stacked_area_comparison
+    fig = stacked_area_comparison(
+        data_left={"Young": [30,25,20], "Mid": [40,45,50], "Senior": [30,30,30]},
+        data_right={"Young": [20,20,25], "Mid": [50,50,45], "Senior": [30,30,30]},
+        categories=["Young", "Mid", "Senior"],
+        x_labels=["Morning", "Afternoon", "Evening"],
+        title="Age Composition",
+        subplot_titles=("Source A", "Source B")
+    )
+    """
+    default_colors = [c for group in [PRIMARY, MEDIUM, DARK, MEDIUM_LIGHT, MEDIUM_DARK, DARKEST, LIGHT] for c in group]
+    palette = colors or default_colors
+
+    def _normalize_to_pct(data_dict: dict, cats: list[str], n_points: int) -> dict[str, list[float]]:
+        """Normalize each slot to sum to 100%."""
+        result = {}
+        for cat in cats:
+            result[cat] = list(data_dict.get(cat, [0.0] * n_points))
+        # Normalize each position
+        for j in range(n_points):
+            total = sum(result[cat][j] for cat in cats)
+            if total > 0:
+                for cat in cats:
+                    result[cat][j] = result[cat][j] / total * 100
+            else:
+                for cat in cats:
+                    result[cat][j] = 0.0
+        return result
+
+    n_points = len(x_labels)
+    left_pct = _normalize_to_pct(data_left, categories, n_points)
+    right_pct = _normalize_to_pct(data_right, categories, n_points)
+
+    fig = make_subplots(rows=1, cols=2, subplot_titles=list(subplot_titles), horizontal_spacing=0.05)
+
+    for data_pct, col_idx in [(left_pct, 1), (right_pct, 2)]:
+        for i, cat in enumerate(categories):
+            color = palette[i % len(palette)]
+            fig.add_trace(go.Scatter(
+                x=x_labels, y=data_pct[cat],
+                name=cat if col_idx == 1 else None,
+                legendgroup=cat, showlegend=(col_idx == 1),
+                stackgroup="one",
+                fillcolor=color,
+                line=dict(width=0.5, color=color),
+                mode="lines",
+            ), row=1, col=col_idx)
+
+    fig.update_layout(
+        title=title, height=height,
+        legend=dict(orientation="h", yanchor="bottom", y=1.05, xanchor="center", x=0.5),
+    )
+    fig.update_xaxes(tickangle=45)
+    fig.update_yaxes(title_text="% of slot", range=[0, 100])
+    return fig
+
+
 if __name__ == "__main__":
     demo_report = ScompLinkHTMLReport("This is a demo report")
 

--- a/scomp_link/utils/report_html.py
+++ b/scomp_link/utils/report_html.py
@@ -46,24 +46,18 @@ _FOOTER_JS_BLOCK = """
                         <script>
                         // Quick and simple export target #table_id into a csv
                         function download_table_as_csv(table_id, separator = ',') {
-                            // Select rows from table_id
                             var rows = document.querySelectorAll('table#' + table_id + ' tr');
-                            // Construct csv
                             var csv = [];
                             for (var i = 0; i < rows.length; i++) {
                                 var row = [], cols = rows[i].querySelectorAll('td, th');
                                 for (var j = 0; j < cols.length; j++) {
-                                    // Clean innertext to remove multiple spaces and jumpline (break csv)
                                     var data = cols[j].innerText.replace(/(\\r\\n|\\n|\\r)/gm, '').replace(/(\\s\\s)/gm, ' ')
-                                    // Escape double-quote with double-double-quote (see https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv)
                                     data = data.replace(/"/g, '""');
-                                    // Push escaped string
                                     row.push('"' + data + '"');
                                 }
                                 csv.push(row.join(separator));
                             }
-                            var csv_string = csv.join('\\n');
-                            // Download it
+                            var csv_string = csv.join('\n');
                             var filename = 'export_' + table_id + '_' + new Date().toLocaleDateString() + '.csv';
                             var link = document.createElement('a');
                             link.style.display = 'none';
@@ -74,10 +68,19 @@ _FOOTER_JS_BLOCK = """
                             link.click();
                             document.body.removeChild(link);
                         }
-                        var coll = document.getElementsByClassName("collapsiblemygs");
-                        var i;
 
-                        for (i = 0; i < coll.length; i++) {
+                        // Resize all Plotly charts within a container
+                        function resizePlotsIn(container) {
+                            if (!window.Plotly) return;
+                            var plots = container.querySelectorAll('.js-plotly-plot');
+                            plots.forEach(function(plot) {
+                                Plotly.Plots.resize(plot);
+                            });
+                        }
+
+                        // Collapsible sections with Plotly resize on open
+                        var coll = document.getElementsByClassName("collapsiblemygs");
+                        for (var i = 0; i < coll.length; i++) {
                           coll[i].addEventListener("click", function() {
                             this.classList.toggle("active");
                             var content = this.nextElementSibling;
@@ -85,91 +88,62 @@ _FOOTER_JS_BLOCK = """
                               content.style.display = "none";
                             } else {
                               content.style.display = "block";
+                              // Resize Plotly charts after section becomes visible
+                              setTimeout(function() { resizePlotsIn(content); }, 50);
+                              setTimeout(function() { resizePlotsIn(content); }, 300);
                             }
                           });
                         }
+
                         document.addEventListener("DOMContentLoaded", function() {
-                            // Function to resize svg-containers, SVG images and rect elements
-                            function resizeElements() {
-                                // Seleziona tutti gli elementi con la classe 'svg-container'
-                                var svgContainers = document.querySelectorAll('.svg-container');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                svgContainers.forEach(function(container) {
-                                    container.style.width = '100%';
+                            // Collapse all sections initially
+                            var contents = document.querySelectorAll('.content');
+                            contents.forEach(function(content) {
+                                content.style.display = 'none';
+                            });
+
+                            // Highcharts containers: ensure 100% width
+                            document.querySelectorAll('.highcharts-container').forEach(function(item) {
+                                item.style.width = '100%';
+                            });
+
+                            // Global ResizeObserver: auto-resize all Plotly charts on container resize
+                            if (window.ResizeObserver && window.Plotly) {
+                                var ro = new ResizeObserver(function(entries) {
+                                    entries.forEach(function(entry) {
+                                        var plot = entry.target.querySelector('.js-plotly-plot') || entry.target;
+                                        if (plot && plot.classList.contains('js-plotly-plot')) {
+                                            Plotly.Plots.resize(plot);
+                                        }
+                                    });
                                 });
-                                
-                                 var svgContainers0 = document.querySelectorAll('.user-select-none');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                svgContainers0.forEach(function(container) {
-                                    container.style.width = '100%';
+                                document.querySelectorAll('.plotly-graph-div').forEach(function(div) {
+                                    ro.observe(div);
                                 });
-                                
-                                
-                                 var cartesianlayer = document.querySelectorAll('.cartesianlayer');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                cartesianlayer.forEach(function(container) {
-                                    container.style.width = '100%';
+                                // Also observe for dynamically added charts
+                                var bodyObserver = new MutationObserver(function(mutations) {
+                                    mutations.forEach(function(m) {
+                                        m.addedNodes.forEach(function(node) {
+                                            if (node.nodeType === 1) {
+                                                var divs = node.querySelectorAll ? node.querySelectorAll('.plotly-graph-div') : [];
+                                                divs.forEach(function(d) { ro.observe(d); });
+                                                if (node.classList && node.classList.contains('plotly-graph-div')) { ro.observe(node); }
+                                            }
+                                        });
+                                    });
                                 });
-                                
-                                
-                        
-                                 var svgContainers1 = document.querySelectorAll('.js-plotly-plot');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                svgContainers1.forEach(function(container) {
-                                    container.style.width = '100%';
-                                });
-                                
-                                
-                                 var svgContainers2 = document.querySelectorAll('.main-svg');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                svgContainers2.forEach(function(container) {
-                                    container.style.width = '100%';
-                                });
-                        
-                                 var svgContainers3 = document.querySelectorAll('.plot-container');
-                        
-                                // Itera su ogni svg-container e imposta la larghezza al 100%
-                                svgContainers3.forEach(function(container) {
-                                    container.style.width = '100%';
-                                });
-                        
-                                // Seleziona tutti gli elementi con il tag '.highcharts-container'
-                                var items = document.querySelectorAll('.highcharts-container');
-                        
-                                // Itera su ogni rect e imposta la larghezza al 100%
-                                items.forEach(function(item) {
-                                    item.style.width = '100%';
-                                });
-                                
-                                
-                                // Seleziona tutti gli elementi con il tag 'select'
-                                var selects = document.querySelectorAll('select');
-                        
-                                // Itera su ogni rect e imposta la larghezza al 100%
-                                selects.forEach(function(select) {
-                                    select.style.width = '200px';
-                                });
-                                
-                                
-                                // Seleziona tutti gli elementi con il tag 'content'
-                                var contents = document.querySelectorAll('.content');
-                        
-                                contents.forEach(function(content) {
-                                    content.style.display = 'none';
-                                });
-                                
-                                 
+                                bodyObserver.observe(document.body, { childList: true, subtree: true });
                             }
-                        
-                            // Call the function when the document is fully loaded
-                            resizeElements();
+
+                            // Fallback: resize all visible Plotly charts on window resize
+                            window.addEventListener('resize', function() {
+                                if (!window.Plotly) return;
+                                document.querySelectorAll('.js-plotly-plot').forEach(function(plot) {
+                                    Plotly.Plots.resize(plot);
+                                });
+                            });
                         });
-                        
+
                         </script>
                         </div><hr><br>"""
 
@@ -303,7 +277,7 @@ class ScompLinkHTMLReport:
               color:white;
               box-shadow:0 4px 12px rgba(0,0,0,.1);
             }
-            .plotly-graph-div{width:100%}
+            .plotly-graph-div{width:100%;min-height:200px;overflow:hidden}
             #container{height:600px}
             .highcharts-label-icon{opacity:0.5}
             .highcharts-figure,.highcharts-data-table table{min-width:310px;max-width:100%;overflow:auto;margin:1em auto}
@@ -539,7 +513,7 @@ class ScompLinkHTMLReport:
               color:white;
               box-shadow:0 4px 12px rgba(0,0,0,.1);
             }
-            .plotly-graph-div{width:100%}
+            .plotly-graph-div{width:100%;min-height:200px;overflow:hidden}
             #container{height:600px}
             .highcharts-label-icon{opacity:0.5}
             .highcharts-figure,.highcharts-data-table table{min-width:310px;max-width:100%;overflow:auto;margin:1em auto}
@@ -662,28 +636,17 @@ class ScompLinkHTMLReport:
         assert fig_json is not None
         fig_dict = json.loads(fig_json)
         jdata = to_json_plotly(fig_dict.get("data", []))
-        jlayout = to_json_plotly(fig_dict.get("layout", {}))
+        layout = fig_dict.get("layout", {})
+        layout["autosize"] = True
+        layout.pop("width", None)  # remove fixed width if set by user
+        jlayout = to_json_plotly(layout)
         jconfig = to_json_plotly({"responsive": True})
         if plotdivid is None:
             plotdivid = title.replace(" ", "_")
             for p in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~":
                 plotdivid = plotdivid.replace(p, "_")
 
-        options = (
-            """ 
-                // Imposta la larghezza al 100%
-                Plotly.update('"""
-            + plotdivid
-            + """', { 'layout.width': window.innerWidth * 0.9 }); // Puoi anche usare '100%' al posto di 'window.innerWidth * 0.9' se preferisci una larghezza fissa
-            
-                // Aggiungi un listener per aggiornare la larghezza quando la finestra viene ridimensionata
-                window.addEventListener('resize', function() {
-                    Plotly.update('"""
-            + plotdivid
-            + """', { 'layout.width': window.innerWidth * 0.9 });
-                });
-                """
-        )
+        options = ""  # autosize handled by responsive config + ResizeObserver
         script = """\
                 <h2>{title}</h2>
                 <div id="{id}" class="plotly-graph-div"></div>

--- a/scomp_link/utils/report_html.py
+++ b/scomp_link/utils/report_html.py
@@ -19,6 +19,8 @@
 import base64
 import io
 import json
+import uuid
+import warnings
 from typing import Any
 
 # Read constants from encrypted file
@@ -700,132 +702,51 @@ class ScompLinkHTMLReport:
 
     def select_plotly(self, figures_dict: dict, title: str, labels="Choose a label") -> str:
         """
+        .. deprecated::
+            Use :meth:`add_cascading_content` instead.
+
         Returns HTML plotly code with select dropdown.
-        :type figures_dict: object
+
+        :param figures_dict: dict mapping label(s) to Plotly figures
+        :param title: str - section title
+        :param labels: str or list[str] - dropdown label(s)
+        :return: empty string (content is appended directly to the report)
         """
-        import random
-
-        option_val = []
-        hide_element = ""
-        script = ""
-        multiple = type(list(figures_dict.keys())[0]) == tuple
-        n_filters = len(list(figures_dict.keys())[0]) if multiple else 1
-        if labels != "Choose a label" and len(labels) == n_filters:
-            labels_ord = list(labels)
-        else:
-            labels_ord = ["Choose a label"] * n_filters
-        title_ = title.replace(" ", "_")
-        for p in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~":
-            title_ = title_.replace(p, "_")
-        if multiple:
-            idhide_ = [f"{i}_{title_}" for i in range(n_filters)]
-        else:
-            idhide_ = [f"1_{title_}"]
-        i = 0
-        for single_title, fig in figures_dict.items():
-            fig_json = to_json_plotly(fig)
-            assert fig_json is not None
-            fig_dict = json.loads(fig_json)
-            jdata = to_json_plotly(fig_dict.get("data", []))
-            jlayout = to_json_plotly(fig_dict.get("layout", {}))
-            jconfig = to_json_plotly({"responsive": True})
-            plotdivid = "".join(single_title).replace(" ", "_")
-            for p in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~":
-                plotdivid = plotdivid.replace(p, "_")
-            idhide = f"{title_}_{plotdivid}"
-            hide_element += f'document.getElementById("{idhide}").style.display = "none"; '
-            display = "block" if i == 0 else "none"
-            i += 1
-            # option_val.append([f'<option value="{idhide}">{single_title}</option>'])
-            if multiple:
-                option_val_tmp = []
-                for k_part in single_title:
-                    k_part_tmp = k_part.replace(" ", "_")
-                    for p in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~":
-                        k_part_tmp = k_part_tmp.replace(p, "_")
-                    option_val_tmp.append(f'<option value="{k_part_tmp}">{k_part}</option>')
-                option_val.append(option_val_tmp)
-            else:
-                single_title_tmp = single_title.replace(" ", "_")
-                for p in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~":
-                    single_title_tmp = single_title_tmp.replace(p, "_")
-                option_val.append([f'<option value="{single_title_tmp}">{single_title}</option>'])
-            id_plotdiv = f"plotdivid_{random.randint(1000, 9999)}"
-            options = (
-                """ 
-                           // Imposta la larghezza al 100%
-                           Plotly.update('"""
-                + id_plotdiv
-                + """', { 'layout.width': window.innerWidth * 0.9 }); // Puoi anche usare '100%' al posto di 'window.innerWidth * 0.9' se preferisci una larghezza fissa
-
-                           // Aggiungi un listener per aggiornare la larghezza quando la finestra viene ridimensionata
-                           window.addEventListener('resize', function() {
-                               Plotly.update('"""
-                + id_plotdiv
-                + """', { 'layout.width': window.innerWidth * 0.9 });
-                           });
-                           """
-            )
-            script += """\
-                    <div id="{idhide}" class="print-grid-item" style="display:{display}">
-                        <h3 class="print-grid-title">{grid_title}</h3>
-                        <div id="{id}" class="plotly-graph-div"></div>
-                        <script>
-                                Plotly.newPlot(\n
-                                    "{id}",\n
-                                    {data},\n
-                                    {layout},\n
-                                    {config}
-                                )
-                                {options}
-                        </script>
-                    </div>
-                        """.format(
-                idhide=idhide,
-                display=display,
-                grid_title=" - ".join(single_title) if isinstance(single_title, tuple) else single_title,
-                id=id_plotdiv,
-                data=jdata,
-                layout=jlayout,
-                config=jconfig,
-                options=options,
-            )
-
-        documentget = f"'{title_}_'+" + "+".join(
-            [f'document.getElementById("labels{idhidepart}").value' for idhidepart in idhide_]
-        ).replace(" ", "_")
-        script = (
-            f"<h2>{title}</h2>\n"
-            + "".join(
-                [
-                    f"""
-                           <label for="labels{idhidepart}">{lab}:</label>
-                             <select name="labels{idhidepart}" id="labels{idhidepart}"  class="form-control js-example-tags">
-                               {''.join(list(set([option_tmp[n] for option_tmp in option_val])))}
-                             </select>
-                         <br><br>"""
-                    for n, [idhidepart, lab] in enumerate(zip(idhide_, labels_ord))
-                ]
-            )
-            + f"""
-                         <input type="submit"  onclick="SelectFunction{title_}()">
-                   """
-            + '<div class="print-grid-container">'
-            + script
-            + "</div>"
-            + """
-                        <script>
-                            function SelectFunction{idhide_}() {start_fun}
-                                {hide_element}
-                                var value = {documentget};
-                                document.getElementById(value).style.display = "block";
-                            {end_fun}
-                        </script>
-                   """.format(
-                idhide_=title_, documentget=documentget, hide_element=hide_element, start_fun="{", end_fun="}"
-            )
+        warnings.warn(
+            "select_plotly() is deprecated, use add_cascading_content() instead",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return script
+
+        # Convert old format to new format
+        keys = list(figures_dict.keys())
+        multiple = isinstance(keys[0], tuple)
+
+        if multiple:
+            n_filters = len(keys[0])
+            if isinstance(labels, (list, tuple)) and len(labels) == n_filters:
+                dim_labels = list(labels)
+            else:
+                dim_labels = [f"Choose a label"] * n_filters
+
+            # Gather unique options per dimension
+            options_per_dim: list[list[str]] = [[] for _ in range(n_filters)]
+            for key_tuple in keys:
+                for i, k in enumerate(key_tuple):
+                    if k not in options_per_dim[i]:
+                        options_per_dim[i].append(k)
+
+            dimensions = [
+                {"label": dim_labels[i], "options": options_per_dim[i]} for i in range(n_filters)
+            ]
+            content_map = {k: v for k, v in figures_dict.items()}
+        else:
+            dim_label = labels if isinstance(labels, str) else labels[0]
+            dimensions = [{"label": dim_label, "options": [str(k) for k in keys]}]
+            content_map = {(str(k),): v for k, v in figures_dict.items()}
+
+        self.add_cascading_content(title, dimensions, content_map)
+        return ""
 
     def add_graph_to_report(self, fig: "plotly.graph_objs._figure.Figure", title: str):
         """
@@ -990,24 +911,29 @@ class ScompLinkHTMLReport:
 
     def add_many_plots_with_selection_box_to_report(self, figures_dict: dict, title: str, **kwargs):
         """
-        Add many graphs to report
-        :param figures_dict: plotly.graph_objs._figure.Figure
-        :param title: str
-        :return:
+        .. deprecated::
+            Use :meth:`add_cascading_content` instead.
+
+        Add multiple Plotly graphs to the report with a dropdown selector.
+
+        :param figures_dict: dict mapping label(s) to Plotly figures
+        :param title: str - section title
+        :param kwargs: optional 'labels' parameter for dropdown label(s)
 
         ## example
-        demo_report = NielsenHTMLreport('My fisrt REPORT') # if you don't have just created
         import plotly.express as px
         fig1 = px.scatter(x=range(10), y=range(10))
         fig2 = px.scatter(x=range(20), y=range(20))
-        figures_dict = {
-                        'This is the first 1':fig1,
-                        'This is the second 2':fig2
-                        }
-        demo_report.add_many_plots_with_selection_box_to_report(figures_dict, 'My first Graph')
+        figures_dict = {'First': fig1, 'Second': fig2}
+        report.add_many_plots_with_selection_box_to_report(figures_dict, 'My Graphs')
         """
+        warnings.warn(
+            "add_many_plots_with_selection_box_to_report() is deprecated, use add_cascading_content() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         labels = kwargs.get("labels", "Choose a label")
-        self.html_report += self.select_plotly(figures_dict, title, labels=labels)
+        self.select_plotly(figures_dict, title, labels=labels)
         logger.info("Added graph to report!")
 
     def open_section(self, section_title: str, ingore_multi_section=False) -> None:
@@ -1087,16 +1013,207 @@ class ScompLinkHTMLReport:
         self.html_report += html
         logger.info("Added raw HTML to report!")
 
-    def add_dataframe(self, df: pd.DataFrame, title: str, limit_max=2000) -> None:
+    def add_cascading_content(
+        self, title: str, dimensions: list[dict], content_map: dict, cascade: bool = False
+    ) -> None:
+        """
+        Add interactive content with cascading dropdown selectors.
+
+        Each combination of dropdown selections maps to a content block (HTML string
+        or Plotly Figure). Only one block is visible at a time.
+
+        :param title: str - heading displayed above the dropdowns
+        :param dimensions: list[dict] - each dict has keys "label" (str) and "options" (list[str])
+        :param content_map: dict - keys are tuples of option strings, values are HTML strings or Plotly Figures
+        :param cascade: bool - if True, child dropdown options are filtered based on parent selection
+
+        ## example
+        import plotly.express as px
+        fig1 = px.scatter(x=[1,2,3], y=[1,2,3])
+        fig2 = px.scatter(x=[1,2,3], y=[3,2,1])
+        report.add_cascading_content(
+            "My Charts",
+            [{"label": "Category", "options": ["A", "B"]}],
+            {("A",): fig1, ("B",): fig2},
+        )
+        """
+        import plotly.graph_objects as go
+        import plotly.io as pio
+
+        uid = uuid.uuid4().hex[:8]
+
+        def _sanitize(s: str) -> str:
+            return s.replace("-", "_").replace(".", "_").replace(" ", "_")
+
+        # Build content divs
+        content_divs = ""
+        first = True
+        for key_tuple, content in content_map.items():
+            sanitized_key = "___".join(_sanitize(str(k)) for k in key_tuple)
+            div_id = f"wrap_{uid}_{sanitized_key}"
+            display = "block" if first else "none"
+            first = False
+
+            if isinstance(content, go.Figure):
+                inner_html = pio.to_html(
+                    content, include_plotlyjs=False, full_html=False, config={"responsive": True}
+                )
+            else:
+                inner_html = str(content)
+
+            content_divs += f'<div id="{div_id}" style="display:{display};overflow:visible;">{inner_html}</div>\n'
+
+        # Build select elements
+        selects_html = ""
+        for i, dim in enumerate(dimensions):
+            sel_id = f"sel_{i}_{uid}"
+            options_html = "".join(
+                f'<option value="{_sanitize(opt)}">{opt}</option>' for opt in dim["options"]
+            )
+            selects_html += (
+                f'<label for="{sel_id}" style="margin-right:6px;font-weight:600;">{dim["label"]}:</label>'
+                f'<select id="{sel_id}" onchange="update_{uid}()" '
+                f'style="margin-right:12px;padding:4px 8px;border-radius:4px;border:1px solid #ccc;">'
+                f"{options_html}</select>\n"
+            )
+
+        # Build cascade JS (filter child options based on parent selections)
+        cascade_js = ""
+        if cascade and len(dimensions) > 1:
+            # Build mapping: parent_value -> available child options for each child dimension
+            cascade_map: dict[int, dict[str, list[str]]] = {}
+            for child_idx in range(1, len(dimensions)):
+                parent_to_children: dict[str, set[str]] = {}
+                for key_tuple in content_map.keys():
+                    parent_key = "___".join(_sanitize(str(k)) for k in key_tuple[:child_idx])
+                    child_val = str(key_tuple[child_idx])
+                    if parent_key not in parent_to_children:
+                        parent_to_children[parent_key] = set()
+                    parent_to_children[parent_key].add(child_val)
+                cascade_map[child_idx] = {k: sorted(v) for k, v in parent_to_children.items()}
+
+            cascade_js = f"var cascade_{uid} = {json.dumps({str(k): v for k, v in cascade_map.items()})};\n"
+            cascade_js += f"""
+            function update_cascade_{uid}() {{
+                var cas = cascade_{uid};
+                for (var ci = 1; ci < {len(dimensions)}; ci++) {{
+                    var parentKey = '';
+                    for (var pi = 0; pi < ci; pi++) {{
+                        if (pi > 0) parentKey += '___';
+                        parentKey += document.getElementById('sel_' + pi + '_{uid}').value;
+                    }}
+                    var sel = document.getElementById('sel_' + ci + '_{uid}');
+                    var opts = (cas[String(ci)] && cas[String(ci)][parentKey]) || [];
+                    var curVal = sel.value;
+                    sel.innerHTML = '';
+                    for (var oi = 0; oi < opts.length; oi++) {{
+                        var o = document.createElement('option');
+                        o.value = opts[oi].replace(/-/g,'_').replace(/\\./g,'_').replace(/ /g,'_');
+                        o.textContent = opts[oi];
+                        sel.appendChild(o);
+                    }}
+                    if (opts.map(function(x){{return x.replace(/-/g,'_').replace(/\\./g,'_').replace(/ /g,'_');}}).indexOf(curVal) >= 0) {{
+                        sel.value = curVal;
+                    }}
+                }}
+            }}
+            """
+
+        # Build update JS
+        key_parts = " + '___' + ".join(
+            f"document.getElementById('sel_{i}_{uid}').value" for i in range(len(dimensions))
+        )
+
+        script = f"""
+<script>
+{cascade_js}
+function update_{uid}() {{
+    {"update_cascade_" + uid + "();" if cascade and len(dimensions) > 1 else ""}
+    var k = {key_parts};
+    document.querySelectorAll('[id^="wrap_{uid}_"]').forEach(function(d) {{ d.style.display = 'none'; }});
+    var tk = k.replace(/-/g, '_').replace(/\\./g, '_').replace(/ /g, '_');
+    var tgt = document.getElementById('wrap_{uid}_' + tk);
+    if (tgt) {{
+        tgt.style.display = 'block';
+        tgt.style.overflow = 'visible';
+        setTimeout(function() {{ window.dispatchEvent(new Event('resize')); }}, 150);
+        setTimeout(function() {{ window.dispatchEvent(new Event('resize')); }}, 500);
+    }}
+}}
+document.addEventListener('DOMContentLoaded', function() {{ update_{uid}(); }});
+setTimeout(function() {{ update_{uid}(); }}, 500);
+</script>
+"""
+
+        self.html_report += f"<h2>{title}</h2>\n"
+        self.html_report += f'<div style="margin-bottom:12px;">{selects_html}</div>\n'
+        self.html_report += content_divs
+        self.html_report += script
+        logger.info("Added cascading content to report!")
+
+    def add_dataframe(self, df, title: str, limit_max=2000, thresholds=None) -> None:
+        """
+        Add a DataFrame as an HTML table to the report.
+
+        :param df: pandas or polars DataFrame
+        :param title: str - table title and CSV download ID
+        :param limit_max: int - maximum rows before skipping rendering (default 2000)
+        :param thresholds: dict[str, tuple[float, float, bool]] or None - color-coding thresholds per column.
+            Format: {"col": (good_threshold, bad_threshold, higher_is_better)}.
+            If higher_is_better=True: value > good → green, bad < value ≤ good → orange, value ≤ bad → red.
+            If higher_is_better=False: value < good → green, good ≤ value < bad → orange, value ≥ bad → red.
+        """
+        # Accept polars DataFrames
+        if hasattr(df, "to_pandas"):
+            df = df.to_pandas()
+
         if len(df) < limit_max:
+            table_id = title.replace(" ", "")
             self.html_report += (
                 '<a href="#" onclick="download_table_as_csv('
-                + f"'{title.replace(' ', '')}'"
+                + f"'{table_id}'"
                 + ');">Download as CSV</a>'
             )
-            tab = df.to_html(index=False, classes="scomp-table").replace('border="1"', 'border="0"')
-            tab = tab.replace('class="dataframe scomp-table"', f'id="{title.replace(" ", "")}" class="scomp-table"')
-            tab = tab.replace('style="text-align: right;"', 'style="text-align: left;"')
+
+            if thresholds is not None:
+                # Build custom HTML table with threshold coloring
+                tab = f'<table id="{table_id}" class="scomp-table">\n<thead><tr>'
+                for col in df.columns:
+                    tab += f"<th>{col}</th>"
+                tab += "</tr></thead>\n<tbody>\n"
+                for _, row in df.iterrows():
+                    tab += "<tr>"
+                    for col in df.columns:
+                        val = row[col]
+                        bg = ""
+                        if col in thresholds:
+                            good, bad, higher_is_better = thresholds[col]
+                            if pd.isna(val):
+                                bg = "rgba(100,100,100,0.2)"
+                            elif higher_is_better:
+                                if val > good:
+                                    bg = "rgba(52,211,153,0.3)"
+                                elif val > bad:
+                                    bg = "rgba(251,146,60,0.3)"
+                                else:
+                                    bg = "rgba(239,68,68,0.3)"
+                            else:
+                                if val < good:
+                                    bg = "rgba(52,211,153,0.3)"
+                                elif val < bad:
+                                    bg = "rgba(251,146,60,0.3)"
+                                else:
+                                    bg = "rgba(239,68,68,0.3)"
+                        style_attr = f' style="background-color:{bg};"' if bg else ""
+                        display_val = "" if pd.isna(val) else val
+                        tab += f"<td{style_attr}>{display_val}</td>"
+                    tab += "</tr>\n"
+                tab += "</tbody></table>"
+            else:
+                tab = df.to_html(index=False, classes="scomp-table").replace('border="1"', 'border="0"')
+                tab = tab.replace('class="dataframe scomp-table"', f'id="{table_id}" class="scomp-table"')
+                tab = tab.replace('style="text-align: right;"', 'style="text-align: left;"')
+
             self.html_report += f"""
             <div id="table-wrapper">
                 <div id="table-scroll">

--- a/tests/test_cascading_and_utils.py
+++ b/tests/test_cascading_and_utils.py
@@ -1,0 +1,391 @@
+"""Tests for add_cascading_content, add_dataframe thresholds, plotly utils, and deprecation wrappers."""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+class TestCascadingContent:
+    """Tests for ScompLinkHTMLReport.add_cascading_content."""
+
+    def _make_report(self):
+        from scomp_link.utils.report_html import ScompLinkHTMLReport
+
+        return ScompLinkHTMLReport("Test Report")
+
+    def test_single_dimension(self):
+        report = self._make_report()
+        dims = [{"label": "Region", "options": ["North", "South"]}]
+        content = {
+            ("North",): "<p>North content</p>",
+            ("South",): "<p>South content</p>",
+        }
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        assert "North content" in html
+        assert "South content" in html
+        assert "display:block" in html or "display: block" in html
+        assert html.count("display:none") >= 1 or html.count("display: none") >= 1
+        assert "<select" in html
+        assert "Region" in html
+
+    def test_two_dimensions(self):
+        report = self._make_report()
+        dims = [
+            {"label": "Region", "options": ["North", "South"]},
+            {"label": "Year", "options": ["2024", "2025"]},
+        ]
+        content = {
+            ("North", "2024"): "<p>N-24</p>",
+            ("North", "2025"): "<p>N-25</p>",
+            ("South", "2024"): "<p>S-24</p>",
+            ("South", "2025"): "<p>S-25</p>",
+        }
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        assert "N-24" in html
+        assert "S-25" in html
+        assert html.count("<select") == 2
+
+    def test_three_dimensions(self):
+        report = self._make_report()
+        dims = [
+            {"label": "A", "options": ["a1", "a2"]},
+            {"label": "B", "options": ["b1"]},
+            {"label": "C", "options": ["c1", "c2"]},
+        ]
+        content = {
+            ("a1", "b1", "c1"): "content_a1b1c1",
+            ("a1", "b1", "c2"): "content_a1b1c2",
+            ("a2", "b1", "c1"): "content_a2b1c1",
+            ("a2", "b1", "c2"): "content_a2b1c2",
+        }
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        assert html.count("<select") == 3
+        assert "content_a1b1c1" in html
+
+    def test_plotly_figure_content(self):
+        import plotly.graph_objects as go
+
+        report = self._make_report()
+        fig = go.Figure(data=[go.Scatter(x=[1, 2], y=[3, 4])])
+        dims = [{"label": "View", "options": ["Chart", "Table"]}]
+        content = {
+            ("Chart",): fig,
+            ("Table",): "<table><tr><td>data</td></tr></table>",
+        }
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        assert "plotly" in html.lower() or "scatter" in html.lower()
+        assert "<table>" in html
+
+    def test_first_item_visible(self):
+        report = self._make_report()
+        dims = [{"label": "X", "options": ["A", "B", "C"]}]
+        content = {("A",): "AAA", ("B",): "BBB", ("C",): "CCC"}
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        # First div should be visible
+        first_div_idx = html.find("AAA")
+        assert first_div_idx > 0
+        # Check that the first wrap div has display:block
+        block_before_first = html[:first_div_idx].rfind("display:")
+        assert "block" in html[block_before_first : block_before_first + 20]
+
+    def test_cascade_mode(self):
+        report = self._make_report()
+        dims = [
+            {"label": "Country", "options": ["US", "EU"]},
+            {"label": "City", "options": ["NYC", "LA", "Berlin", "Paris"]},
+        ]
+        content = {
+            ("US", "NYC"): "US-NYC",
+            ("US", "LA"): "US-LA",
+            ("EU", "Berlin"): "EU-Berlin",
+            ("EU", "Paris"): "EU-Paris",
+        }
+        report.add_cascading_content("Test", dims, content, cascade=True)
+        html = report.html_report
+        # Should contain JSON options mapping for cascading
+        assert "US" in html
+        assert "Berlin" in html
+
+    def test_special_chars_in_options(self):
+        report = self._make_report()
+        dims = [{"label": "Item", "options": ["foo-bar", "hello world", "a.b.c"]}]
+        content = {
+            ("foo-bar",): "content1",
+            ("hello world",): "content2",
+            ("a.b.c",): "content3",
+        }
+        report.add_cascading_content("Test", dims, content)
+        # Should not crash — special chars sanitized in IDs
+        html = report.html_report
+        assert "content1" in html
+        assert "content2" in html
+        assert "content3" in html
+
+    def test_js_contains_update_function(self):
+        report = self._make_report()
+        dims = [{"label": "X", "options": ["A", "B"]}]
+        content = {("A",): "a", ("B",): "b"}
+        report.add_cascading_content("Test", dims, content)
+        html = report.html_report
+        assert "function update_" in html or "function upd_" in html
+        assert "DOMContentLoaded" in html
+        assert "resize" in html
+
+
+class TestDataframeThresholds:
+    """Tests for add_dataframe with threshold-based conditional formatting."""
+
+    def _make_report(self):
+        from scomp_link.utils.report_html import ScompLinkHTMLReport
+
+        return ScompLinkHTMLReport("Test Report")
+
+    def test_no_thresholds_unchanged(self):
+        report = self._make_report()
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        report.add_dataframe(df, "Test Table")
+        html = report.html_report
+        assert "scomp-table" in html
+        assert "download_table_as_csv" in html
+
+    def test_thresholds_green_orange_red(self):
+        report = self._make_report()
+        df = pd.DataFrame({"metric": [0.05, 0.15, 0.30]})
+        thresholds = {"metric": (0.10, 0.25, False)}  # lower is better
+        report.add_dataframe(df, "Metrics", thresholds=thresholds)
+        html = report.html_report
+        assert "rgba(52,211,153,0.3)" in html  # green for 0.05
+        assert "rgba(251,146,60,0.3)" in html  # orange for 0.15
+        assert "rgba(239,68,68,0.3)" in html  # red for 0.30
+
+    def test_thresholds_higher_is_better(self):
+        report = self._make_report()
+        df = pd.DataFrame({"accuracy": [0.95, 0.70, 0.30]})
+        thresholds = {"accuracy": (0.8, 0.5, True)}  # higher is better
+        report.add_dataframe(df, "Acc", thresholds=thresholds)
+        html = report.html_report
+        assert "rgba(52,211,153,0.3)" in html  # green for 0.95
+        assert "rgba(251,146,60,0.3)" in html  # orange for 0.70
+        assert "rgba(239,68,68,0.3)" in html  # red for 0.30
+
+    def test_thresholds_nan_grey(self):
+        report = self._make_report()
+        df = pd.DataFrame({"val": [0.5, float("nan"), 0.1]})
+        thresholds = {"val": (0.3, 0.6, False)}
+        report.add_dataframe(df, "NaN Test", thresholds=thresholds)
+        html = report.html_report
+        assert "rgba(100,100,100,0.2)" in html  # grey for NaN
+
+    def test_thresholds_polars_input(self):
+        try:
+            import polars as pl
+        except ImportError:
+            pytest.skip("polars not installed")
+        report = self._make_report()
+        df = pl.DataFrame({"score": [0.9, 0.5, 0.2]})
+        thresholds = {"score": (0.7, 0.4, True)}
+        report.add_dataframe(df, "Polars Test", thresholds=thresholds)
+        html = report.html_report
+        assert "rgba(52,211,153,0.3)" in html
+
+    def test_thresholds_multiple_columns(self):
+        report = self._make_report()
+        df = pd.DataFrame({"error": [0.01, 0.2, 0.5], "r2": [0.99, 0.6, 0.3]})
+        thresholds = {
+            "error": (0.1, 0.3, False),
+            "r2": (0.8, 0.5, True),
+        }
+        report.add_dataframe(df, "Multi", thresholds=thresholds)
+        html = report.html_report
+        # Both green cells should be present
+        assert html.count("rgba(52,211,153,0.3)") >= 2
+
+
+class TestPlotlyUtils:
+    """Tests for new plotly utility functions."""
+
+    def test_fill_timeslots_pad(self):
+        from scomp_link.utils.plotly_utils import fill_timeslots
+
+        result = fill_timeslots([1, 2, 3], 5)
+        assert len(result) == 5
+        assert result[0] == 1.0
+        assert result[3] == 0.0
+        assert result[4] == 0.0
+
+    def test_fill_timeslots_truncate(self):
+        from scomp_link.utils.plotly_utils import fill_timeslots
+
+        result = fill_timeslots([1, 2, 3, 4, 5], 3)
+        assert len(result) == 3
+        assert list(result) == [1.0, 2.0, 3.0]
+
+    def test_fill_timeslots_exact(self):
+        from scomp_link.utils.plotly_utils import fill_timeslots
+
+        result = fill_timeslots([1, 2, 3], 3)
+        assert len(result) == 3
+        assert list(result) == [1.0, 2.0, 3.0]
+
+    def test_fill_timeslots_custom_fill(self):
+        from scomp_link.utils.plotly_utils import fill_timeslots
+
+        result = fill_timeslots([1], 3, fill_value=-1.0)
+        assert list(result) == [1.0, -1.0, -1.0]
+
+    def test_normalize_to_index_basic(self):
+        from scomp_link.utils.plotly_utils import normalize_to_index
+
+        result = normalize_to_index([2, 4, 6], baseline=100)
+        assert abs(result.mean() - 100) < 1e-10
+        assert abs(result[0] - 50) < 1e-10
+        assert abs(result[2] - 150) < 1e-10
+
+    def test_normalize_to_index_zeros(self):
+        from scomp_link.utils.plotly_utils import normalize_to_index
+
+        result = normalize_to_index([0, 0, 0], baseline=100)
+        assert all(v == 0 for v in result)
+
+    def test_normalize_to_index_custom_baseline(self):
+        from scomp_link.utils.plotly_utils import normalize_to_index
+
+        result = normalize_to_index([1, 1, 1], baseline=50)
+        assert abs(result.mean() - 50) < 1e-10
+
+    def test_index_chart_simple(self):
+        from scomp_link.utils.plotly_utils import index_chart
+
+        fig = index_chart(
+            {"A": [1, 2, 3, 4], "B": [4, 3, 2, 1]},
+            x_labels=["Q1", "Q2", "Q3", "Q4"],
+            title="Test Index",
+        )
+        assert hasattr(fig, "data")
+        assert len(fig.data) == 2  # one trace per series
+        assert fig.layout.title.text == "Test Index — A"
+
+    def test_index_chart_paired(self):
+        from scomp_link.utils.plotly_utils import index_chart
+
+        fig = index_chart(
+            {
+                "X": {"solid": [1, 2], "dashed": [2, 1]},
+                "Y": {"solid": [3, 4], "dashed": [4, 3]},
+            },
+            x_labels=["a", "b"],
+            title="Paired",
+        )
+        assert len(fig.data) == 4  # 2 groups × 2 traces
+        # Check first group visible, second hidden
+        assert fig.data[0].visible is True or fig.data[0].visible is None
+        assert fig.data[2].visible is False
+
+    def test_index_chart_has_buttons(self):
+        from scomp_link.utils.plotly_utils import index_chart
+
+        fig = index_chart(
+            {"A": [1, 2], "B": [3, 4]},
+            x_labels=["x", "y"],
+            title="Test",
+        )
+        assert fig.layout.updatemenus is not None
+        assert len(fig.layout.updatemenus) == 1
+        # buttons: one per series + "All"
+        assert len(fig.layout.updatemenus[0].buttons) == 3
+
+    def test_stacked_area_comparison(self):
+        from scomp_link.utils.plotly_utils import stacked_area_comparison
+
+        fig = stacked_area_comparison(
+            data_left={"A": [30, 40], "B": [70, 60]},
+            data_right={"A": [50, 50], "B": [50, 50]},
+            categories=["A", "B"],
+            x_labels=["t1", "t2"],
+            title="Compare",
+            subplot_titles=("Left", "Right"),
+        )
+        assert hasattr(fig, "data")
+        # 2 categories × 2 subplots = 4 traces
+        assert len(fig.data) == 4
+
+    def test_stacked_area_normalizes_to_100(self):
+        from scomp_link.utils.plotly_utils import stacked_area_comparison
+
+        fig = stacked_area_comparison(
+            data_left={"A": [10, 20], "B": [30, 40]},
+            data_right={"A": [5, 5], "B": [5, 5]},
+            categories=["A", "B"],
+            x_labels=["t1", "t2"],
+            title="Norm Test",
+        )
+        # Left subplot: first slot A=25%, B=75%
+        assert abs(fig.data[0].y[0] - 25.0) < 1e-10
+        assert abs(fig.data[1].y[0] - 75.0) < 1e-10
+
+
+class TestDeprecation:
+    """Tests for deprecated select_plotly and add_many_plots_with_selection_box_to_report."""
+
+    def _make_report(self):
+        from scomp_link.utils.report_html import ScompLinkHTMLReport
+
+        return ScompLinkHTMLReport("Test Report")
+
+    def test_select_plotly_emits_warning(self):
+        import plotly.graph_objects as go
+
+        report = self._make_report()
+        figs = {"fig1": go.Figure(), "fig2": go.Figure()}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            report.select_plotly(figs, "Test")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "add_cascading_content" in str(w[0].message)
+
+    def test_select_plotly_still_works(self):
+        import plotly.graph_objects as go
+
+        report = self._make_report()
+        figs = {"A": go.Figure(), "B": go.Figure()}
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            report.select_plotly(figs, "Test")
+        assert len(report.html_report) > 0
+        assert "<select" in report.html_report
+
+    def test_add_many_plots_emits_warning(self):
+        import plotly.graph_objects as go
+
+        report = self._make_report()
+        figs = {"fig1": go.Figure(), "fig2": go.Figure()}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            report.add_many_plots_with_selection_box_to_report(figs, "Test")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_select_plotly_tuple_keys(self):
+        import plotly.graph_objects as go
+
+        report = self._make_report()
+        figs = {
+            ("US", "2024"): go.Figure(),
+            ("US", "2025"): go.Figure(),
+            ("EU", "2024"): go.Figure(),
+            ("EU", "2025"): go.Figure(),
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            report.select_plotly(figs, "Multi", labels=["Region", "Year"])
+        html = report.html_report
+        assert len(html) > 0
+        assert "<select" in html


### PR DESCRIPTION
## Summary

Adds interactive report features:

### New: `add_cascading_content()`
N-dimensional interactive dropdown navigation for reports. Supports:
- Any number of dimension dropdowns (Client × Year × Metric, etc.)
- Content can be HTML strings or Plotly Figures (auto-converted)
- Independent mode (default) or cascade mode (child options filter by parent)
- UUID-namespaced JS for multiple cascading sections in one report

### Enhanced: `add_dataframe()` with thresholds
Optional `thresholds` parameter for conditional cell coloring:
```python
report.add_dataframe(df, 'Metrics', thresholds={
    'error': (0.10, 0.25, False),   # lower is better
    'r2': (0.80, 0.50, True),       # higher is better
})
```
Green/orange/red coloring with NaN handling. Fully backward-compatible.

### New: Plotly chart utilities
- `fill_timeslots(values, n_slots)` — pad/truncate arrays
- `normalize_to_index(values, baseline=100)` — index normalization
- `index_chart(series_dict, x_labels, title)` — toggle-button index charts
- `stacked_area_comparison(left, right, categories, x_labels, title)` — side-by-side 100% stacked areas

### Deprecated
`select_plotly()` and `add_many_plots_with_selection_box_to_report()` — replaced by `add_cascading_content()` (wrappers still work, emit DeprecationWarning).

## Testing
- 30 new tests in `tests/test_cascading_and_utils.py` — all passing
- No regressions in existing test suite
- Example: `examples/example_35_cascading_report.py`