### PR TITLE
fix: collapsible sections not toggling

### DIFF
--- a/scomp_link/utils/report_html.py
+++ b/scomp_link/utils/report_html.py
@@ -57,7 +57,7 @@ _FOOTER_JS_BLOCK = """
                                 }
                                 csv.push(row.join(separator));
                             }
-                            var csv_string = csv.join('\n');
+                            var csv_string = csv.join('\\n');
                             var filename = 'export_' + table_id + '_' + new Date().toLocaleDateString() + '.csv';
                             var link = document.createElement('a');
                             link.style.display = 'none';
@@ -80,23 +80,28 @@ _FOOTER_JS_BLOCK = """
 
                         // Collapsible sections with Plotly resize on open
                         var coll = document.getElementsByClassName("collapsiblemygs");
+                        // Collapse all sections immediately (do not rely on DOMContentLoaded which may have already fired)
+                        for (var ci = 0; ci < coll.length; ci++) {
+                            var sibling = coll[ci].nextElementSibling;
+                            if (sibling) sibling.style.display = 'none';
+                        }
                         for (var i = 0; i < coll.length; i++) {
                           coll[i].addEventListener("click", function() {
                             this.classList.toggle("active");
                             var content = this.nextElementSibling;
-                            if (content.style.display === "block") {
-                              content.style.display = "none";
-                            } else {
+                            if (content.style.display === "none") {
                               content.style.display = "block";
                               // Resize Plotly charts after section becomes visible
                               setTimeout(function() { resizePlotsIn(content); }, 50);
                               setTimeout(function() { resizePlotsIn(content); }, 300);
+                            } else {
+                              content.style.display = "none";
                             }
                           });
                         }
 
                         document.addEventListener("DOMContentLoaded", function() {
-                            // Collapse all sections initially
+                            // Collapse all sections (fallback)
                             var contents = document.querySelectorAll('.content');
                             contents.forEach(function(content) {
                                 content.style.display = 'none';


### PR DESCRIPTION
## Summary

Fixes collapsible sections (open/close) not working in HTML reports.

## Root Cause

Two issues in `_FOOTER_JS_BLOCK`:

1. **JS SyntaxError**: `csv.join('\n')` in the Python triple-quoted string produced a literal newline in the HTML output, breaking the JS string literal. This aborted the entire `<script>` block — including the collapsible section handler that comes later in the same block.

2. **DOMContentLoaded race**: The initial collapse of sections relied on `DOMContentLoaded`, but since the script is at the end of `<body>`, the event may have already fired. Sections now collapse immediately when the script executes.

## Changes

- Escape `\n` properly in csv.join so it outputs valid JS
- Collapse sections immediately (inline) instead of waiting for DOMContentLoaded  
- Invert toggle logic to check for `display === 'none'` (the guaranteed initial state)

## Testing

- Generated HTML reports with collapsible sections + cascading content
- Verified sections start collapsed, open on first click, close on second click
- No JS console errors